### PR TITLE
Lots with numeric id

### DIFF
--- a/CSM.ParkingData.csproj
+++ b/CSM.ParkingData.csproj
@@ -156,7 +156,7 @@
     <Compile Include="ViewModels\MeteredSpaceGET.cs" />
     <Compile Include="ViewModels\MeteredSpacePOST.cs" />
     <Compile Include="ViewModels\MeteredSpacePOSTCollection.cs" />
-    <Compile Include="ViewModels\ParkingLot.cs" />
+    <Compile Include="ViewModels\ParkingLotGET.cs" />
     <Compile Include="ViewModels\SensorEventGET.cs" />
     <Compile Include="ViewModels\SensorEventLifetime.cs" />
     <Compile Include="ViewModels\SensorEventMeteredSpacePOST.cs" />

--- a/Controllers/LotsController.cs
+++ b/Controllers/LotsController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Web.Http;
 using CSM.ParkingData.Filters;
 using CSM.ParkingData.Services;
@@ -19,12 +18,12 @@ namespace CSM.ParkingData.Controllers
 
         [TrackAnalytics("GET Lots")]
         [HttpGet]
-        public IHttpActionResult Get(string name = null)
+        public IHttpActionResult Get(long? id = null)
         {
             var lots = _parkingLotsService.Get();
 
-            if(!String.IsNullOrEmpty(name))
-                lots = lots.Where(l => l.Name.ToLower().Contains(name.ToLower()));
+            if(id.HasValue)
+                lots = lots.Where(l => l.Id == id);
 
             if(lots.Any())
             {

--- a/Controllers/LotsController.cs
+++ b/Controllers/LotsController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Web.Http;
 using CSM.ParkingData.Filters;
 using CSM.ParkingData.Services;
@@ -18,7 +19,7 @@ namespace CSM.ParkingData.Controllers
 
         [TrackAnalytics("GET Lots")]
         [HttpGet]
-        public IHttpActionResult Get(long? id = null)
+        public IHttpActionResult GetDefault(long? id = null)
         {
             var lots = _parkingLotsService.Get();
 
@@ -26,6 +27,25 @@ namespace CSM.ParkingData.Controllers
                 lots = lots.Where(l => l.Id == id);
 
             if(lots.Any())
+            {
+                return Ok(lots);
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [TrackAnalytics("GET Lots Matching")]
+        [HttpGet]
+        public IHttpActionResult GetMatching(string name)
+        {
+            if (String.IsNullOrEmpty(name))
+                return BadRequest("name parameter cannot be empty.");
+
+            var lots = _parkingLotsService.Get().Where(l => l.Name.ToLower().Contains(name.ToLower()));
+            
+            if (lots.Any())
             {
                 return Ok(lots);
             }

--- a/Routes/LotRoutes.cs
+++ b/Routes/LotRoutes.cs
@@ -13,11 +13,25 @@ namespace CSM.ParkingData.Routes
         {
             return new[] {
                 new HttpRouteDescriptor() {
+                    Name = "LotsMatching",
+                    Priority = Routes.DefaultPriority,
+                    RouteTemplate = "lots/matching/{name}",
+                    Defaults = new {
+                        area = Routes.Area,
+                        action = "GetMatching",
+                        controller = _controller,
+                    },
+                    Constraints = new { 
+                        name = Routes.NonEmptyStringContraint
+                    }
+                },
+                new HttpRouteDescriptor() {
                     Name = "LotsDefault",
                     Priority = Routes.DefaultPriority,
                     RouteTemplate = "lots/{id}",
                     Defaults = new {
                         area = Routes.Area,
+                        action = "GetDefault",
                         controller = _controller,
                         id = RouteParameter.Optional
                     }

--- a/Routes/LotRoutes.cs
+++ b/Routes/LotRoutes.cs
@@ -15,11 +15,11 @@ namespace CSM.ParkingData.Routes
                 new HttpRouteDescriptor() {
                     Name = "LotsDefault",
                     Priority = Routes.DefaultPriority,
-                    RouteTemplate = "lots/{name}",
+                    RouteTemplate = "lots/{id}",
                     Defaults = new {
                         area = Routes.Area,
                         controller = _controller,
-                        name = RouteParameter.Optional
+                        id = RouteParameter.Optional
                     }
                 }
             };

--- a/Routes/Routes.cs
+++ b/Routes/Routes.cs
@@ -9,6 +9,7 @@
 
         public static readonly int DefaultPriority = 5;
 
+        public static readonly string NonEmptyStringContraint = @"^.+$";
         public static readonly string DateTimeConstraint = @"^\d{8}T\d{6}Z$";
         public static readonly string OrdinalConstraint = @"^\d+$";
     }

--- a/Services/IParkingLotsService.cs
+++ b/Services/IParkingLotsService.cs
@@ -12,14 +12,14 @@ namespace CSM.ParkingData.Services
     public interface IParkingLotsService : IDependency
     {
         /// <summary>
-        /// Get the collection of <see cref="CSM.ParkingData.ViewModels.ParkingLot"/> records.
+        /// Get the collection of <see cref="CSM.ParkingData.ViewModels.ParkingLotGET"/> records.
         /// </summary>
-        IEnumerable<ParkingLot> Get();
+        IEnumerable<ParkingLotGET> Get();
 
         /// <summary>
-        /// Parse the xml representation of a parking lot into its <see cref="CSM.ParkingData.ViewModels.ParkingLot"/> representation.
+        /// Parse the xml representation of a parking lot into its <see cref="CSM.ParkingData.ViewModels.ParkingLotGET"/> representation.
         /// </summary>
-        ParkingLot ParseFromXml(XElement xml);
+        ParkingLotGET ParseFromXml(XElement xml);
 
         /// <summary>
         /// Parse the xml representation of the last update date and time into its <see cref="System.DateTime"/> representation.

--- a/Services/ParkingLotsService.cs
+++ b/Services/ParkingLotsService.cs
@@ -17,7 +17,7 @@ namespace CSM.ParkingData.Services
             _clock = clock;
         }
 
-        public IEnumerable<ParkingLot> Get()
+        public IEnumerable<ParkingLotGET> Get()
         {
             string lotDataUrl = CloudConfigurationManager.GetSetting("ParkingLotDataUrl");
             XDocument xdocument;
@@ -29,13 +29,13 @@ namespace CSM.ParkingData.Services
             }
             catch
             {
-                return Enumerable.Empty<ParkingLot>();
+                return Enumerable.Empty<ParkingLotGET>();
             }
         }
 
-        public IEnumerable<ParkingLot> Get(XDocument lotXml)
+        public IEnumerable<ParkingLotGET> Get(XDocument lotXml)
         {
-            var parkingLots = new List<ParkingLot>();
+            var parkingLots = new List<ParkingLotGET>();
             DateTime lastUpdateUtc = ParseLastUpdateUtc(lotXml.Root);
 
             foreach (var lot in lotXml.Root.Elements("lot"))
@@ -48,11 +48,11 @@ namespace CSM.ParkingData.Services
             return parkingLots;
         }
 
-        public ParkingLot ParseFromXml(XElement xml)
+        public ParkingLotGET ParseFromXml(XElement xml)
         {
             try
             {
-                return new ParkingLot() {
+                return new ParkingLotGET() {
                     AvailableSpaces = Convert.ToInt32(xml.Element("available").Value),
                     Description = xml.Element("description").Value,
                     Latitude = Convert.ToDecimal(xml.Element("latitude").Value),

--- a/Tests/Lots/ControllerTests.cs
+++ b/Tests/Lots/ControllerTests.cs
@@ -23,10 +23,10 @@ namespace CSM.ParkingData.Tests.Lots
             _mockLotService
                 .Setup(m => m.Get())
                 .Returns(() => new[] { 
-                    new ParkingLot { Name = "Lot1", AvailableSpaces = 0 },
-                    new ParkingLot { Name = "Lot2", AvailableSpaces = 100 },
-                    new ParkingLot { Name = "Structure1", AvailableSpaces = 0 },
-                    new ParkingLot { Name = "Structure2", AvailableSpaces = 100 }
+                    new ParkingLotGET { Name = "Lot1", AvailableSpaces = 0 },
+                    new ParkingLotGET { Name = "Lot2", AvailableSpaces = 100 },
+                    new ParkingLotGET { Name = "Structure1", AvailableSpaces = 0 },
+                    new ParkingLotGET { Name = "Structure2", AvailableSpaces = 100 }
                 });
 
             _controller = new LotsController(_mockLotService.Object);
@@ -37,7 +37,7 @@ namespace CSM.ParkingData.Tests.Lots
         public void Get_ReturnsParkingLotCollection()
         {
             IHttpActionResult actionResult = _controller.Get();
-            var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLot>>;
+            var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
 
             Assert.NotNull(contentResult);
             Assert.NotNull(contentResult.Content);
@@ -50,7 +50,7 @@ namespace CSM.ParkingData.Tests.Lots
         public void GetWithName_ReturnsParkingLotCollection_FuzzyMatchingName()
         {
             IHttpActionResult actionResult = _controller.Get("lot");
-            var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLot>>;
+            var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
 
             Assert.NotNull(contentResult);
             Assert.NotNull(contentResult.Content);
@@ -62,7 +62,7 @@ namespace CSM.ParkingData.Tests.Lots
             Assert.AreEqual(100, contentResult.Content.Aggregate(0, (total, lot) => total += lot.AvailableSpaces));
 
             actionResult = _controller.Get("struct");
-            contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLot>>;
+            contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
 
             Assert.NotNull(contentResult);
             Assert.NotNull(contentResult.Content);

--- a/Tests/Lots/ControllerTests.cs
+++ b/Tests/Lots/ControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
 using System.Web.Http.Results;
@@ -22,11 +23,11 @@ namespace CSM.ParkingData.Tests.Lots
             _mockLotService = new Mock<IParkingLotsService>();
             _mockLotService
                 .Setup(m => m.Get())
-                .Returns(() => new[] { 
-                    new ParkingLotGET { Name = "Lot1", AvailableSpaces = 0 },
-                    new ParkingLotGET { Name = "Lot2", AvailableSpaces = 100 },
-                    new ParkingLotGET { Name = "Structure1", AvailableSpaces = 0 },
-                    new ParkingLotGET { Name = "Structure2", AvailableSpaces = 100 }
+                .Returns(() => new[] {
+                    new ParkingLotGET { Name = "Lot 1", AvailableSpaces = 0 },
+                    new ParkingLotGET { Name = "Lot 2", AvailableSpaces = 100 },
+                    new ParkingLotGET { Name = "Structure 1", AvailableSpaces = 0 },
+                    new ParkingLotGET { Name = "Structure 2", AvailableSpaces = 100 }
                 });
 
             _controller = new LotsController(_mockLotService.Object);
@@ -34,9 +35,9 @@ namespace CSM.ParkingData.Tests.Lots
 
         [Test]
         [Category("Lots")]
-        public void Get_ReturnsParkingLotCollection()
+        public void GetDefault_ReturnsParkingLotCollection()
         {
-            IHttpActionResult actionResult = _controller.Get();
+            IHttpActionResult actionResult = _controller.GetDefault();
             var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
 
             Assert.NotNull(contentResult);
@@ -47,9 +48,36 @@ namespace CSM.ParkingData.Tests.Lots
 
         [Test]
         [Category("Lots")]
-        public void GetWithName_ReturnsParkingLotCollection_FuzzyMatchingName()
+        public void GetDefault_WithId_ReturnsParkingLotWithId()
         {
-            IHttpActionResult actionResult = _controller.Get("lot");
+            //the id for Lot 1
+            long id = 7649;
+
+            IHttpActionResult actionResult = _controller.GetDefault(id);
+            var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
+
+            Assert.NotNull(contentResult);
+            Assert.NotNull(contentResult.Content);
+            Assert.AreEqual(1, contentResult.Content.Count());
+            Assert.AreEqual(id, contentResult.Content.Single().Id);
+        }
+
+        [TestCase((string)null)]
+        [TestCase("")]
+        [Category("Lots")]
+        public void GetMatching_WithoutName_ReturnsBadRequest(string badName)
+        {
+            IHttpActionResult actionResult = _controller.GetMatching(badName);
+            var contentResult = actionResult as BadRequestErrorMessageResult;
+
+            Assert.NotNull(contentResult);
+        }
+
+        [Test]
+        [Category("Lots")]
+        public void GetMatching_WithName_ReturnsParkingLotCollection_FuzzyMatchingName()
+        {
+            IHttpActionResult actionResult = _controller.GetMatching("lot");
             var contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
 
             Assert.NotNull(contentResult);
@@ -57,11 +85,11 @@ namespace CSM.ParkingData.Tests.Lots
             Assert.AreEqual(2, contentResult.Content.Count());
             foreach (var result in contentResult.Content)
             {
-                StringAssert.IsMatch(@"Lot\d", result.Name);
+                StringAssert.IsMatch(@"Lot \d", result.Name);
             }
             Assert.AreEqual(100, contentResult.Content.Aggregate(0, (total, lot) => total += lot.AvailableSpaces));
 
-            actionResult = _controller.Get("struct");
+            actionResult = _controller.GetMatching("struct");
             contentResult = actionResult as OkNegotiatedContentResult<IEnumerable<ParkingLotGET>>;
 
             Assert.NotNull(contentResult);
@@ -69,7 +97,7 @@ namespace CSM.ParkingData.Tests.Lots
             Assert.AreEqual(2, contentResult.Content.Count());
             foreach (var result in contentResult.Content)
             {
-                StringAssert.IsMatch(@"Structure\d", result.Name);
+                StringAssert.IsMatch(@"Structure \d", result.Name);
             }
             Assert.AreEqual(100, contentResult.Content.Aggregate(0, (total, lot) => total += lot.AvailableSpaces));
         }

--- a/Tests/Lots/SerializationTests.cs
+++ b/Tests/Lots/SerializationTests.cs
@@ -17,13 +17,16 @@ namespace CSM.ParkingData.Tests.Lots
             var lot = new ParkingLotGET {
                 AvailableSpaces = 100,
                 Description = "Description here",
-                Name = "Lot1",
+                Name = "Lot 1",
                 LastUpdate = new DateTime(2015, 5, 8, 15, 0, 0, DateTimeKind.Utc), 
                 Latitude = 42.0M,
                 Longitude = -42.0M,
                 StreetAddress = "123 Main Street",
                 ZipCode = 99999
             };
+
+            //the computed Id should match *before* serialization
+            Assert.AreEqual(lot.Id, 7649);
 
             //act
 
@@ -33,7 +36,8 @@ namespace CSM.ParkingData.Tests.Lots
 
             StringAssert.IsMatch(@"""available_spaces"":100", serialized);
             StringAssert.IsMatch(@"""description"":""Description here""", serialized);
-            StringAssert.IsMatch(@"""name"":""Lot1""", serialized);
+            StringAssert.IsMatch(@"""name"":""Lot 1""", serialized);
+            StringAssert.IsMatch(@"""id"":7649", serialized);
             StringAssert.IsMatch(@"""last_update"":""20150508T150000Z""", serialized);
             StringAssert.IsMatch(@"""latitude"":42.0", serialized);
             StringAssert.IsMatch(@"""longitude"":-42.0", serialized);

--- a/Tests/Lots/SerializationTests.cs
+++ b/Tests/Lots/SerializationTests.cs
@@ -14,7 +14,7 @@ namespace CSM.ParkingData.Tests.Lots
         {
             //arrange
 
-            var lot = new ParkingLot {
+            var lot = new ParkingLotGET {
                 AvailableSpaces = 100,
                 Description = "Description here",
                 Name = "Lot1",

--- a/Tests/Lots/ServiceTests.cs
+++ b/Tests/Lots/ServiceTests.cs
@@ -81,7 +81,7 @@ namespace CSM.ParkingData.Tests.Lots
         {
             XElement xml = lotXmlStub("100", "somewhere", "42.42", "-42.42", "some lot", "123 Main Street", "12345");
 
-            ParkingLot parkingLot = _service.ParseFromXml(xml);
+            ParkingLotGET parkingLot = _service.ParseFromXml(xml);
 
             Assert.AreEqual(100, parkingLot.AvailableSpaces);
             Assert.AreEqual("somewhere", parkingLot.Description);
@@ -102,7 +102,7 @@ namespace CSM.ParkingData.Tests.Lots
                                     new XElement("longitude", "bad"),
                                     new XElement("zip", "not gonna work"));
 
-            ParkingLot parkingLot = _service.ParseFromXml(parkingLotXml);
+            ParkingLotGET parkingLot = _service.ParseFromXml(parkingLotXml);
 
             Assert.IsNull(parkingLot);
         }

--- a/ViewModels/ParkingLotGET.cs
+++ b/ViewModels/ParkingLotGET.cs
@@ -6,7 +6,7 @@ using CSM.ParkingData.Extensions;
 namespace CSM.ParkingData.ViewModels
 {
     [DataContract(Name = "lot", Namespace = "")]
-    public class ParkingLot
+    public class ParkingLotGET
     {
         [DataMember(Name = "available_spaces")]
         public int AvailableSpaces { get; set; }

--- a/ViewModels/ParkingLotGET.cs
+++ b/ViewModels/ParkingLotGET.cs
@@ -21,7 +21,7 @@ namespace CSM.ParkingData.ViewModels
             get
             {
                 //split the name on space
-                //take the first character in each piece as uppsercase
+                //take the first character in each piece as uppercase
                 //convert to ASCII value
                 var nameValues = Name.Split(' ').SelectMany(s => s.Substring(0,1).ToUpper()).Select(c => Convert.ToInt16(c));
                 //combine into long

--- a/ViewModels/ParkingLotGET.cs
+++ b/ViewModels/ParkingLotGET.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Runtime.Serialization;
 using CSM.ParkingData.Extensions;
 
@@ -13,6 +14,21 @@ namespace CSM.ParkingData.ViewModels
 
         [DataMember(Name = "description")]
         public string Description { get; set; }
+
+        [DataMember(Name = "id")]
+        public long Id
+        {
+            get
+            {
+                //split the name on space
+                //take the first character in each piece as uppsercase
+                //convert to ASCII value
+                var nameValues = Name.Split(' ').SelectMany(s => s.Substring(0,1).ToUpper()).Select(c => Convert.ToInt16(c));
+                //combine into long
+                return long.Parse(String.Join("", nameValues));
+            }
+            private set { ; }
+        }
 
         public DateTime LastUpdate { get; set; }
 


### PR DESCRIPTION
As requested in our break-out session on Saturday. 

The `/lots` endpoint now optionally accepts the id, rather than doing a fuzzy-match on lot name.

A new endpoint `/lots/matching/:name` has been added, which takes on the behavior of the previous fuzzy-matching default endpoint. 