### PR TITLE
Latest sensor event endpoints

### DIFF
--- a/Controllers/SensorEventsController.cs
+++ b/Controllers/SensorEventsController.cs
@@ -57,6 +57,17 @@ namespace CSM.ParkingData.Controllers
             return Ok(events);
         }
 
+        [TrackAnalytics("GET Sensor Events at Meter Latest")]
+        [HttpGet]
+        public IHttpActionResult AtMeterLatest(string meterId)
+        {
+            if (!_meteredSpacesService.Exists(meterId))
+                return NotFound();
+
+            var latest = _sensorEventsService.GetLatestViewModel(meterId);
+            return Ok(latest);
+        }
+
         [TrackAnalytics("GET Sensor Events at Meter")]
         [HttpGet]
         public IHttpActionResult AtMeter(string meterId)
@@ -96,6 +107,14 @@ namespace CSM.ParkingData.Controllers
         {
             var events = _sensorEventsService.GetViewModelsSince(ordinal);
             return Ok(events);
+        }
+
+        [TrackAnalytics("GET Sensor Events Latest")]
+        [HttpGet] 
+        public IHttpActionResult Latest()
+        {
+            var latest = _sensorEventsService.GetLatestViewModel();
+            return Ok(latest);
         }
 
         [TrackAnalytics("GET Sensor Events")]

--- a/Routes/SensorEventRoutes.cs
+++ b/Routes/SensorEventRoutes.cs
@@ -39,6 +39,16 @@ namespace CSM.ParkingData.Routes
                     }
                 },
                 new HttpRouteDescriptor() {
+                    Name = "SensorEventsAtMeterLatest",
+                    Priority = Routes.DefaultPriority,
+                    RouteTemplate = String.Format("{0}/latest", Routes.BaseEventAtRoute),
+                    Defaults = new {
+                        area = Routes.Area,
+                        controller = _controller,
+                        action = "AtMeterLatest"
+                    }
+                },
+                new HttpRouteDescriptor() {
                     Name = "SensorEventsAtMeter",
                     Priority = Routes.DefaultPriority,
                     RouteTemplate = Routes.BaseEventAtRoute,
@@ -61,7 +71,7 @@ namespace CSM.ParkingData.Routes
                         datetime = Routes.DateTimeConstraint
                     }
                 },
-                 new HttpRouteDescriptor() {
+                new HttpRouteDescriptor() {
                     Name = "SensorEventsSinceOrdinal",
                     Priority = Routes.DefaultPriority,
                     RouteTemplate = String.Format("{0}/since/{{ordinal}}", Routes.BaseEventRoute),
@@ -72,6 +82,16 @@ namespace CSM.ParkingData.Routes
                     },
                     Constraints = new {
                         ordinal = Routes.OrdinalConstraint
+                    }
+                },
+                new HttpRouteDescriptor() {
+                    Name = "SensorEventsLatest",
+                    Priority = Routes.DefaultPriority,
+                    RouteTemplate = String.Format("{0}/latest", Routes.BaseEventRoute),
+                    Defaults = new {
+                        area = Routes.Area,
+                        controller = _controller,
+                        action = "Latest"
                     }
                 },
                 new HttpRouteDescriptor() {

--- a/Services/ISensorEventsService.cs
+++ b/Services/ISensorEventsService.cs
@@ -33,6 +33,17 @@ namespace CSM.ParkingData.Services
         SensorEventGET GetViewModel(SensorEvent entity);
 
         /// <summary>
+        /// Gets the most recently recorded sensor event
+        /// </summary>
+        SensorEventGET GetLatestViewModel();
+
+        /// <summary>
+        /// Gets the most recently recorded sensor event at the MeteredSpace with the specified id.
+        /// </summary>
+        /// <param name="meterId"></param>
+        SensorEventGET GetLatestViewModel(string meterId);
+
+        /// <summary>
         /// Return a queryable collection of SensorEvent records.
         /// </summary>
         IQueryable<SensorEvent> Query();

--- a/Services/SensorEventsService.cs
+++ b/Services/SensorEventsService.cs
@@ -117,6 +117,21 @@ namespace CSM.ParkingData.Services
             };
         }
 
+        public SensorEventGET GetLatestViewModel()
+        {
+            return GetLatestViewModel(null);
+        }
+
+        public SensorEventGET GetLatestViewModel(string meterId)
+        {
+            var query = Query();
+
+            if (!String.IsNullOrEmpty(meterId))
+                query = query.Where(s => s.MeteredSpace.MeterId == meterId);
+
+            return GetViewModel(query.First());
+        }
+
         public IQueryable<SensorEvent> Query()
         {
             return _sensorEventsRepo


### PR DESCRIPTION
This PR defines two new endpoints for sensor events:

    /meters/events/latest

    /meters/<meter_id>/events/latest

Each of which returns the single, most recent sensor event (the former across all meters, the latter at a specific meter). 

This should help with the issues raised in #33 