### PR TITLE
Improve query for latest event at meter

### DIFF
--- a/Services/SensorEventsService.cs
+++ b/Services/SensorEventsService.cs
@@ -124,12 +124,9 @@ namespace CSM.ParkingData.Services
 
         public SensorEventGET GetLatestViewModel(string meterId)
         {
-            var query = Query();
+            var lifetime = GetMaxLifetime();
 
-            if (!String.IsNullOrEmpty(meterId))
-                query = query.Where(s => s.MeteredSpace.MeterId == meterId);
-
-            return GetViewModel(query.First());
+            return GetViewModelsSince(lifetime.Since, meterId).FirstOrDefault();
         }
 
         public IQueryable<SensorEvent> Query()


### PR DESCRIPTION
Previously, the query didn't restrict by time when searching for the most recent event at a meter.

The new implementation uses the maximum lifetime as a lower bound on the search domain. This seems to improve the performance.

In the new implementation, if a meter has not seen activity since before the maximum lifetime, then calls to get the latest event at that meter will be `200 OK` but result in `null`. This is consistent with the API, although could be re-examined in separate discussion. 