### PR TITLE
Optimize sensor event queries

### DIFF
--- a/CSM.ParkingData.csproj
+++ b/CSM.ParkingData.csproj
@@ -24,6 +24,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -115,7 +116,6 @@
     <ProjectReference Include="..\CSM.WebApi\CSM.WebApi.csproj">
       <Project>{44c685fd-fc5e-41a8-a4dd-20896ca1f77e}</Project>
       <Name>CSM.WebApi</Name>
-      <Private>True</Private>
     </ProjectReference>
     <ProjectReference Include="..\Orchard.Caching\Orchard.Caching.csproj">
       <Project>{7528bf74-25c7-4abe-883a-443b4eec4776}</Project>

--- a/CSM.ParkingData.csproj
+++ b/CSM.ParkingData.csproj
@@ -57,7 +57,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\lib\windowsazure\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>

--- a/Filters/TrackAnalyticsAttribute.cs
+++ b/Filters/TrackAnalyticsAttribute.cs
@@ -2,8 +2,8 @@
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using GoogleAnalyticsTracker.WebApi2;
-using Microsoft.WindowsAzure;
 using Orchard;
+using Microsoft.Azure;
 
 namespace CSM.ParkingData.Filters
 {

--- a/Module.txt
+++ b/Module.txt
@@ -3,7 +3,7 @@ AntiForgery: enabled
 Author: City of Santa Monica
 Website: https://github.com/CityofSantaMonica/Orchard.ParkingData
 Version: 1.0
-OrchardVersion: 1.9
+OrchardVersion: 1.9.2
 Description: RESTful Web API for the City of Santa Monica's Parking Data.
 Dependencies: CSM.WebApi.Security, Orchard.Caching
 Category: Open Data

--- a/Services/ISensorEventsService.cs
+++ b/Services/ISensorEventsService.cs
@@ -23,6 +23,11 @@ namespace CSM.ParkingData.Services
         SensorEventLifetime GetDefaultLifetime();
 
         /// <summary>
+        /// Return a queryable collection of SensorEvent records.
+        /// </summary>
+        IQueryable<SensorEvent> Query();
+
+        /// <summary>
         /// Given the sensor event data in a POSTed view model, insert a new record or update an existing record.
         /// </summary>
         SensorEvent AddOrUpdate(SensorEventPOST viewModel);
@@ -42,11 +47,6 @@ namespace CSM.ParkingData.Services
         /// </summary>
         /// <param name="meterId"></param>
         SensorEventGET GetLatestViewModel(string meterId);
-
-        /// <summary>
-        /// Return a queryable collection of SensorEvent records.
-        /// </summary>
-        IQueryable<SensorEvent> Query();
 
         /// <summary>
         /// Get a collection of view models occuring since the specified DateTime.

--- a/Services/ParkingLotsService.cs
+++ b/Services/ParkingLotsService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using CSM.ParkingData.ViewModels;
-using Microsoft.WindowsAzure;
+using Microsoft.Azure;
 using Orchard.Services;
 
 namespace CSM.ParkingData.Services

--- a/Services/SensorEventsService.cs
+++ b/Services/SensorEventsService.cs
@@ -69,6 +69,14 @@ namespace CSM.ParkingData.Services
             return lifetime;
         }
 
+        public IQueryable<SensorEvent> Query()
+        {
+            return _sensorEventsRepo
+                    .Table
+                    //pre-fetch the metered spaces to speed up later joins
+                    .Fetch(s => s.MeteredSpace);
+        }
+
         public SensorEvent AddOrUpdate(SensorEventPOST viewModel)
         {
             //try to get an existing meter, by looking in a local cache first
@@ -127,14 +135,6 @@ namespace CSM.ParkingData.Services
             var lifetime = GetMaxLifetime();
 
             return GetViewModelsSince(lifetime.Since, meterId).FirstOrDefault();
-        }
-
-        public IQueryable<SensorEvent> Query()
-        {
-            return _sensorEventsRepo
-                    .Table
-                    //pre-fetch the metered spaces to speed up later joins
-                    .Fetch(s => s.MeteredSpace);
         }
 
         public IEnumerable<SensorEventGET> GetViewModelsSince(DateTime datetime)

--- a/Services/SensorEventsService.cs
+++ b/Services/SensorEventsService.cs
@@ -133,9 +133,8 @@ namespace CSM.ParkingData.Services
         {
             return _sensorEventsRepo
                     .Table
-                    //taking advantage of the clustered index on Id
-                    //since we normally want the most recent events (which are at the end)
-                    .OrderByDescending(s => s.Id);
+                    //pre-fetch the metered spaces to speed up later joins
+                    .Fetch(s => s.MeteredSpace);
         }
 
         public IEnumerable<SensorEventGET> GetViewModelsSince(DateTime datetime)

--- a/Tests/CSM.ParkingData.Tests.csproj
+++ b/Tests/CSM.ParkingData.Tests.csproj
@@ -92,13 +92,13 @@
     <Compile Include="TestsBase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CSM.ParkingData.csproj">
-      <Project>{c7057b20-646b-4ba4-80fa-b4dc7b15b908}</Project>
-      <Name>CSM.ParkingData</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\Orchard\Orchard.Framework.csproj">
       <Project>{2d1d92bb-4555-4cbe-8d0e-63563d6ce4c6}</Project>
       <Name>Orchard.Framework</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\CSM.ParkingData.csproj">
+      <Project>{c7057b20-646b-4ba4-80fa-b4dc7b15b908}</Project>
+      <Name>CSM.ParkingData</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Web.config
+++ b/Web.config
@@ -39,7 +39,6 @@
   </system.web>
 
   <system.webServer>
-    
     <rewrite>
       <rules>
         <clear/>

--- a/Web.config
+++ b/Web.config
@@ -1,27 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
   <configSections>
     <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
-      <remove name="host" />
-      <remove name="pages" />
-      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
-      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+      <remove name="host"/>
+      <remove name="pages"/>
+      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false"/>
+      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false"/>
     </sectionGroup>
   </configSections>
 
   <system.web.webPages.razor>
-    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
     <pages pageBaseType="Orchard.Mvc.ViewEngines.Razor.WebViewPage">
       <namespaces>
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Web.WebPages" />
-        <add namespace="System.Linq" />
-        <add namespace="System.Collections.Generic" />
-        <add namespace="Orchard.Mvc.Html" />
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Web.WebPages"/>
+        <add namespace="System.Linq"/>
+        <add namespace="System.Collections.Generic"/>
+        <add namespace="Orchard.Mvc.Html"/>
       </namespaces>
     </pages>
   </system.web.webPages.razor>
@@ -29,11 +29,11 @@
   <system.web>
     <compilation targetFramework="4.5.1">
       <assemblies>
-        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B77A5C561934E089" />
-        <add assembly="System.Web.Mvc, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add assembly="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add assembly="System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=B77A5C561934E089"/>
+        <add assembly="System.Web.Mvc, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add assembly="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
       </assemblies>
     </compilation>
   </system.web>
@@ -42,20 +42,20 @@
     
     <rewrite>
       <rules>
-        <clear />
+        <clear/>
         <rule name="Canonical Host Name">
-          <match url="(.*)" />
+          <match url="(.*)"/>
           <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
-            <add input="{HTTP_HOST}" pattern="^parking\.api\.smgov\.net$" negate="true" />
+            <add input="{HTTP_HOST}" pattern="^parking\.api\.smgov\.net$" negate="true"/>
           </conditions>
-          <action type="Redirect" url="https://parking.api.smgov.net/{R:1}" />
+          <action type="Redirect" url="https://parking.api.smgov.net/{R:1}"/>
         </rule>
         <rule name="Enforce HTTPS" stopProcessing="true">
-          <match url="(.*)" />
+          <match url="(.*)"/>
           <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
-            <add input="{HTTPS}" pattern="off" />
+            <add input="{HTTPS}" pattern="off"/>
           </conditions>
-          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}"/>
         </rule>
       </rules>
     </rewrite>
@@ -64,32 +64,32 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This PR addresses some of the performance problems, e.g. reported in #33 and #38 .

It turns out the sensor event queries were caught in a fairly obvious (in hindsight :facepunch:) [Select N+1](http://stackoverflow.com/questions/97197/what-is-the-n1-selects-issue) loop. 

A simple change really, thanks to a suggestion from @kevinsmgov, is to pre-fetch all meters ahead of any query for sensor events. The underlying framework (NHibernate) provides nice semantics for this operation.
